### PR TITLE
Update LLVM in cpp-ethereum-base docker.

### DIFF
--- a/cpp-ethereum-base/Dockerfile
+++ b/cpp-ethereum-base/Dockerfile
@@ -17,14 +17,11 @@ RUN add-apt-repository ppa:ethereum/ethereum
 RUN apt-get update
 RUN apt-get install -qy libcryptopp-dev libjson-rpc-cpp-dev
 
-# LLVM-3.5
+# LLVM
 RUN wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add -
-RUN echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.5 main\ndeb-src http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.5 main" > /etc/apt/sources.list.d/llvm-trusty.list
+RUN echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty main" > /etc/apt/sources.list.d/llvm-trusty.list
 RUN apt-get update
-RUN apt-get install -qy llvm-3.5 libedit-dev
-
-# Fix llvm-3.5 cmake paths
-RUN mkdir -p /usr/lib/llvm-3.5/share/llvm && ln -s /usr/share/llvm-3.5/cmake /usr/lib/llvm-3.5/share/llvm/cmake
+RUN apt-get install -qy llvm-3.5-dev libedit-dev libz-dev
 
 # Qt5
 RUN add-apt-repository ppa:ethereum/ethereum-qt


### PR DESCRIPTION
Workaround for incorrect LLVM cmake files is not needed as I fixed that upstream.

Also use more generic APT repo to be prepared for LLVM 3.7.